### PR TITLE
feat: CurveTokenV5

### DIFF
--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -1,4 +1,10 @@
+reports:
+  exclude_paths:
+    - contracts/testing/*.*
+  only_include_project: false
+
 networks:
-    development:
-        cmd_settings:
-            chain_id: 1337
+  development:
+    cmd_settings:
+      default_balance: 1000000
+      chain_id: 1337

--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -1,9 +1,4 @@
-reports:
-  exclude_paths:
-    - contracts/testing/*.*
-  only_include_project: false
-
 networks:
-  development:
-    cmd_settings:
-      default_balance: 1000000
+    development:
+        cmd_settings:
+            chain_id: 1337

--- a/contracts/CurveTokenV5.vy
+++ b/contracts/CurveTokenV5.vy
@@ -1,0 +1,221 @@
+# @version 0.3.0
+"""
+@title Curve LP Token
+@author Curve.Fi
+@notice Base implementation for an LP token provided for
+        supplying liquidity to `StableSwap`
+@dev Follows the ERC-20 token standard as defined at
+     https://eips.ethereum.org/EIPS/eip-20
+"""
+
+from vyper.interfaces import ERC20
+
+implements: ERC20
+
+interface Curve:
+    def owner() -> address: view
+
+
+event Transfer:
+    _from: indexed(address)
+    _to: indexed(address)
+    _value: uint256
+
+event Approval:
+    _owner: indexed(address)
+    _spender: indexed(address)
+    _value: uint256
+
+event SetName:
+    old_name: String[64]
+    old_symbol: String[32]
+    name: String[64]
+    symbol: String[32]
+    owner: address
+    time: uint256
+
+
+name: public(String[64])
+symbol: public(String[32])
+
+balanceOf: public(HashMap[address, uint256])
+allowance: public(HashMap[address, HashMap[address, uint256]])
+totalSupply: public(uint256)
+
+minter: public(address)
+
+
+@external
+def __init__(_name: String[64], _symbol: String[32]):
+    self.name = _name
+    self.symbol = _symbol
+    self.minter = msg.sender
+    log Transfer(ZERO_ADDRESS, msg.sender, 0)
+
+
+@view
+@external
+def decimals() -> uint256:
+    """
+    @notice Get the number of decimals for this token
+    @dev Implemented as a view method to reduce gas costs
+    @return uint256 decimal places
+    """
+    return 18
+
+
+@external
+def transfer(_to : address, _value : uint256) -> bool:
+    """
+    @dev Transfer token for a specified address
+    @param _to The address to transfer to.
+    @param _value The amount to be transferred.
+    """
+    # NOTE: vyper does not allow underflows
+    #       so the following subtraction would revert on insufficient balance
+    self.balanceOf[msg.sender] -= _value
+    self.balanceOf[_to] += _value
+
+    log Transfer(msg.sender, _to, _value)
+    return True
+
+
+@external
+def transferFrom(_from : address, _to : address, _value : uint256) -> bool:
+    """
+     @dev Transfer tokens from one address to another.
+     @param _from address The address which you want to send tokens from
+     @param _to address The address which you want to transfer to
+     @param _value uint256 the amount of tokens to be transferred
+    """
+    self.balanceOf[_from] -= _value
+    self.balanceOf[_to] += _value
+
+    _allowance: uint256 = self.allowance[_from][msg.sender]
+    if _allowance != MAX_UINT256:
+        self.allowance[_from][msg.sender] = _allowance - _value
+
+    log Transfer(_from, _to, _value)
+    return True
+
+
+@external
+def approve(_spender : address, _value : uint256) -> bool:
+    """
+    @notice Approve the passed address to transfer the specified amount of
+            tokens on behalf of msg.sender
+    @dev Beware that changing an allowance via this method brings the risk
+         that someone may use both the old and new allowance by unfortunate
+         transaction ordering. This may be mitigated with the use of
+         {increaseAllowance} and {decreaseAllowance}.
+         https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+    @param _spender The address which will transfer the funds
+    @param _value The amount of tokens that may be transferred
+    @return bool success
+    """
+    self.allowance[msg.sender][_spender] = _value
+
+    log Approval(msg.sender, _spender, _value)
+    return True
+
+
+@external
+def increaseAllowance(_spender: address, _added_value: uint256) -> bool:
+    """
+    @notice Increase the allowance granted to `_spender` by the caller
+    @dev This is alternative to {approve} that can be used as a mitigation for
+         the potential race condition
+    @param _spender The address which will transfer the funds
+    @param _added_value The amount of to increase the allowance
+    @return bool success
+    """
+    allowance: uint256 = self.allowance[msg.sender][_spender] + _added_value
+    self.allowance[msg.sender][_spender] = allowance
+
+    log Approval(msg.sender, _spender, allowance)
+    return True
+
+
+@external
+def decreaseAllowance(_spender: address, _subtracted_value: uint256) -> bool:
+    """
+    @notice Decrease the allowance granted to `_spender` by the caller
+    @dev This is alternative to {approve} that can be used as a mitigation for
+         the potential race condition
+    @param _spender The address which will transfer the funds
+    @param _subtracted_value The amount of to decrease the allowance
+    @return bool success
+    """
+    allowance: uint256 = self.allowance[msg.sender][_spender] - _subtracted_value
+    self.allowance[msg.sender][_spender] = allowance
+
+    log Approval(msg.sender, _spender, allowance)
+    return True
+
+
+@external
+def mint(_to: address, _value: uint256) -> bool:
+    """
+    @dev Mint an amount of the token and assigns it to an account.
+         This encapsulates the modification of balances such that the
+         proper events are emitted.
+    @param _to The account that will receive the created tokens.
+    @param _value The amount that will be created.
+    """
+    assert msg.sender == self.minter
+
+    self.totalSupply += _value
+    self.balanceOf[_to] += _value
+
+    log Transfer(ZERO_ADDRESS, _to, _value)
+    return True
+
+
+@external
+def mint_relative(_to: address, frac: uint256) -> uint256:
+    """
+    @dev Increases supply by factor of (1 + frac/1e18) and mints it for _to
+    """
+    assert msg.sender == self.minter
+
+    supply: uint256 = self.totalSupply
+    d_supply: uint256 = supply * frac / 10**18
+    if d_supply > 0:
+        self.totalSupply = supply + d_supply
+        self.balanceOf[_to] += d_supply
+        log Transfer(ZERO_ADDRESS, _to, d_supply)
+
+    return d_supply
+
+
+@external
+def burnFrom(_to: address, _value: uint256) -> bool:
+    """
+    @dev Burn an amount of the token from a given account.
+    @param _to The account whose tokens will be burned.
+    @param _value The amount that will be burned.
+    """
+    assert msg.sender == self.minter
+
+    self.totalSupply -= _value
+    self.balanceOf[_to] -= _value
+
+    log Transfer(_to, ZERO_ADDRESS, _value)
+    return True
+
+
+@external
+def set_minter(_minter: address):
+    assert msg.sender == self.minter
+    self.minter = _minter
+
+
+@external
+def set_name(_name: String[64], _symbol: String[32]):
+    assert Curve(self.minter).owner() == msg.sender
+    old_name: String[64] = self.name
+    old_symbol: String[32] = self.symbol
+    self.name = _name
+    self.symbol = _symbol
+
+    log SetName(old_name, old_symbol, _name, _symbol, msg.sender, block.timestamp)

--- a/contracts/CurveTokenV5.vy
+++ b/contracts/CurveTokenV5.vy
@@ -1,4 +1,4 @@
-# @version 0.3.0
+# @version 0.3.1
 """
 @title Curve LP Token
 @author Curve.Fi
@@ -7,32 +7,20 @@
 @dev Follows the ERC-20 token standard as defined at
      https://eips.ethereum.org/EIPS/eip-20
 """
-
 from vyper.interfaces import ERC20
 
 implements: ERC20
 
-interface Curve:
-    def owner() -> address: view
-
-
-event Transfer:
-    _from: indexed(address)
-    _to: indexed(address)
-    _value: uint256
 
 event Approval:
     _owner: indexed(address)
     _spender: indexed(address)
     _value: uint256
 
-event SetName:
-    old_name: String[64]
-    old_symbol: String[32]
-    name: String[64]
-    symbol: String[32]
-    owner: address
-    time: uint256
+event Transfer:
+    _from: indexed(address)
+    _to: indexed(address)
+    _value: uint256
 
 
 name: public(String[64])
@@ -208,14 +196,3 @@ def burnFrom(_to: address, _value: uint256) -> bool:
 def set_minter(_minter: address):
     assert msg.sender == self.minter
     self.minter = _minter
-
-
-@external
-def set_name(_name: String[64], _symbol: String[32]):
-    assert Curve(self.minter).owner() == msg.sender
-    old_name: String[64] = self.name
-    old_symbol: String[32] = self.symbol
-    self.name = _name
-    self.symbol = _symbol
-
-    log SetName(old_name, old_symbol, _name, _symbol, msg.sender, block.timestamp)

--- a/contracts/CurveTokenV5.vy
+++ b/contracts/CurveTokenV5.vy
@@ -137,6 +137,7 @@ def permit(
     """
     @notice Approves spender by owner's signature to expend owner's tokens.
         See https://eips.ethereum.org/EIPS/eip-2612.
+    @dev Inspired by https://github.com/yearn/yearn-vaults/blob/main/contracts/Vault.vy#L753-L793
     @dev Supports smart contract wallets which implement ERC1271
         https://eips.ethereum.org/EIPS/eip-1271
     @param _owner The address which is a source of funds and has signed the Permit.

--- a/contracts/CurveTokenV5.vy
+++ b/contracts/CurveTokenV5.vy
@@ -22,9 +22,14 @@ event Transfer:
     _to: indexed(address)
     _value: uint256
 
+event SetMinter:
+    _old_minter: address
+    _new_minter: address
 
-name: public(String[64])
-symbol: public(String[32])
+
+NAME: immutable(String[64])
+SYMBOL: immutable(String[32])
+
 
 balanceOf: public(HashMap[address, uint256])
 allowance: public(HashMap[address, HashMap[address, uint256]])
@@ -35,25 +40,18 @@ minter: public(address)
 
 @external
 def __init__(_name: String[64], _symbol: String[32]):
-    self.name = _name
-    self.symbol = _symbol
+    NAME = _name
+    SYMBOL = _symbol
+
     self.minter = msg.sender
+    log SetMinter(ZERO_ADDRESS, msg.sender)
+
+    # fire a transfer event so block explorers identify the contract as an ERC20
     log Transfer(ZERO_ADDRESS, msg.sender, 0)
 
 
-@view
 @external
-def decimals() -> uint256:
-    """
-    @notice Get the number of decimals for this token
-    @dev Implemented as a view method to reduce gas costs
-    @return uint256 decimal places
-    """
-    return 18
-
-
-@external
-def transfer(_to : address, _value : uint256) -> bool:
+def transfer(_to: address, _value: uint256) -> bool:
     """
     @dev Transfer token for a specified address
     @param _to The address to transfer to.
@@ -69,7 +67,7 @@ def transfer(_to : address, _value : uint256) -> bool:
 
 
 @external
-def transferFrom(_from : address, _to : address, _value : uint256) -> bool:
+def transferFrom(_from: address, _to: address, _value: uint256) -> bool:
     """
      @dev Transfer tokens from one address to another.
      @param _from address The address which you want to send tokens from
@@ -88,7 +86,7 @@ def transferFrom(_from : address, _to : address, _value : uint256) -> bool:
 
 
 @external
-def approve(_spender : address, _value : uint256) -> bool:
+def approve(_spender: address, _value: uint256) -> bool:
     """
     @notice Approve the passed address to transfer the specified amount of
             tokens on behalf of msg.sender
@@ -194,5 +192,41 @@ def burnFrom(_to: address, _value: uint256) -> bool:
 
 @external
 def set_minter(_minter: address):
+    """
+    @notice Set the address allowed to mint tokens
+    @dev Emits the `SetMinter` event
+    @param _minter The address to set as the minter
+    """
     assert msg.sender == self.minter
+
+    log SetMinter(msg.sender, _minter)
     self.minter = _minter
+
+
+@view
+@external
+def name() -> String[64]:
+    """
+    @notice Get the name for this token
+    """
+    return NAME
+
+
+@view
+@external
+def symbol() -> String[32]:
+    """
+    @notice Get the symbol for this token
+    """
+    return SYMBOL
+
+
+@view
+@external
+def decimals() -> uint8:
+    """
+    @notice Get the number of decimals for this token
+    @dev Implemented as a view method to reduce gas costs
+    @return uint8 decimal places
+    """
+    return 18

--- a/tests/token/conftest.py
+++ b/tests/token/conftest.py
@@ -1,0 +1,27 @@
+import pytest
+
+
+@pytest.fixture(scope="session")
+def alice(accounts):
+    return accounts[0]
+
+
+@pytest.fixture(scope="session")
+def bob(accounts):
+    return accounts[1]
+
+
+@pytest.fixture(scope="session")
+def charlie(accounts):
+    return accounts[2]
+
+
+@pytest.fixture(scope="module")
+def token(alice, CurveTokenV5):
+    return CurveTokenV5.deploy("Sample Token", "ST", {"from": alice})
+
+
+@pytest.fixture(autouse=True)
+def isolate(fn_isolation):
+    pass
+

--- a/tests/token/test_approve.py
+++ b/tests/token/test_approve.py
@@ -113,3 +113,37 @@ def test_permit(accounts, bob, chain, token, web3):
     assert tx.events["Approval"].values() == [alice.address, bob, 2 ** 256 - 1]
     assert token.nonces(alice) == 1
 
+
+def test_permit_contract(accounts, bob, chain, token, web3):
+
+    src = """
+@view
+@external
+def isValidSignature(_hash: bytes32, _sig: Bytes[65]) -> bytes32:
+    return 0x1626ba7e00000000000000000000000000000000000000000000000000000000
+    """
+    mock_contract = brownie.compile_source(src, vyper_version="0.3.1").Vyper.deploy({"from": bob})
+    alice = accounts.add("0x416b8a7d9290502f5661da81f0cf43893e3d19cb9aea3c426cfb36e8186e9c09")
+
+    class Permit(EIP712Message):
+        # EIP-712 Domain Fields
+        _name_: "string" = token.name()
+        _version_: "string" = token.version()
+        _chainId_: "uint256" = chain.id
+        _verifyingContract_: "address" = token.address
+
+        # EIP-2612 Data Fields
+        owner: "address"
+        spender: "address"
+        value: "uint256"
+        nonce: "uint256"
+        deadline: "uint256" = 2 ** 256 - 1
+
+    permit = Permit(owner=alice.address, spender=bob.address, value=2 ** 256 - 1, nonce=0)
+    sig = alice.sign_message(permit)
+
+    tx = token.permit(mock_contract, bob, 2 ** 256 - 1, 2 ** 256 - 1, sig.v, sig.r, sig.s)
+
+    # make sure this is hit when owner is a contract
+    assert tx.subcalls[0]["function"] == "isValidSignature(bytes32,bytes)"
+

--- a/tests/token/test_approve.py
+++ b/tests/token/test_approve.py
@@ -1,0 +1,115 @@
+import brownie
+import pytest
+from eip712.messages import EIP712Message
+
+
+@pytest.mark.parametrize("idx", range(5))
+def test_initial_approval_is_zero(alice, accounts, idx, token):
+    assert token.allowance(alice, accounts[idx]) == 0
+
+
+def test_approve(alice, bob, token):
+    token.approve(bob, 10 ** 19, {"from": alice})
+
+    assert token.allowance(alice, bob) == 10 ** 19
+
+
+def test_modify_approve_nonzero(alice, bob, token):
+    token.approve(bob, 10 ** 19, {"from": alice})
+    token.approve(bob, 12345678, {"from": alice})
+
+    assert token.allowance(alice, bob) == 12345678
+
+
+def test_modify_approve_zero_nonzero(alice, bob, token):
+    token.approve(bob, 10 ** 19, {"from": alice})
+    token.approve(bob, 0, {"from": alice})
+    token.approve(bob, 12345678, {"from": alice})
+
+    assert token.allowance(alice, bob) == 12345678
+
+
+def test_revoke_approve(alice, bob, token):
+    token.approve(bob, 10 ** 19, {"from": alice})
+    token.approve(bob, 0, {"from": alice})
+
+    assert token.allowance(alice, bob) == 0
+
+
+def test_approve_self(alice, bob, token):
+    token.approve(alice, 10 ** 19, {"from": alice})
+
+    assert token.allowance(alice, alice) == 10 ** 19
+
+
+def test_only_affects_target(alice, bob, token):
+    token.approve(bob, 10 ** 19, {"from": alice})
+
+    assert token.allowance(bob, alice) == 0
+
+
+def test_returns_true(alice, bob, token):
+    tx = token.approve(bob, 10 ** 19, {"from": alice})
+
+    assert tx.return_value is True
+
+
+def test_approval_event_fires(alice, bob, token):
+    tx = token.approve(bob, 10 ** 19, {"from": alice})
+
+    assert len(tx.events) == 1
+    assert tx.events["Approval"].values() == [alice, bob, 10 ** 19]
+
+
+def test_infinite_approval(alice, bob, token):
+    token.mint(alice, 10 ** 18, {"from": alice})
+
+    token.approve(bob, 2 ** 256 - 1, {"from": alice})
+    token.transferFrom(alice, bob, 10 ** 18, {"from": bob})
+
+    assert token.allowance(alice, bob) == 2 ** 256 - 1
+
+
+def test_increase_allowance(alice, bob, token):
+    token.approve(bob, 100, {"from": alice})
+    token.increaseAllowance(bob, 403, {"from": alice})
+
+    assert token.allowance(alice, bob) == 503
+
+
+def test_decrease_allowance(alice, bob, token):
+    token.approve(bob, 100, {"from": alice})
+    token.decreaseAllowance(bob, 34, {"from": alice})
+
+    assert token.allowance(alice, bob) == 66
+
+
+def test_permit(accounts, bob, chain, token, web3):
+
+    alice = accounts.add("0x416b8a7d9290502f5661da81f0cf43893e3d19cb9aea3c426cfb36e8186e9c09")
+
+    class Permit(EIP712Message):
+        # EIP-712 Domain Fields
+        _name_: "string" = token.name()
+        _version_: "string" = token.version()
+        _chainId_: "uint256" = chain.id
+        _verifyingContract_: "address" = token.address
+
+        # EIP-2612 Data Fields
+        owner: "address"
+        spender: "address"
+        value: "uint256"
+        nonce: "uint256"
+        deadline: "uint256" = 2 ** 256 - 1
+
+    permit = Permit(owner=alice.address, spender=bob.address, value=2 ** 256 - 1, nonce=0)
+    sig = alice.sign_message(permit)
+
+    tx = token.permit(alice, bob, 2 ** 256 - 1, 2 ** 256 - 1, sig.v, sig.r, sig.s)
+
+    assert token.allowance(alice, bob) == 2 ** 256 - 1
+    assert tx.return_value is True
+    assert len(tx.events) == 1
+    assert tx.events["Approval"].values() == [alice.address, bob, 2 ** 256 - 1]
+    assert token.nonces(alice) == 1
+

--- a/tests/token/test_transfer.py
+++ b/tests/token/test_transfer.py
@@ -1,0 +1,85 @@
+import pytest
+import brownie
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(alice, token):
+    token.mint(alice, 10 ** 21, {"from": alice})
+
+
+def test_sender_balance_decreases(alice, bob, token):
+    sender_balance = token.balanceOf(alice)
+    amount = sender_balance // 4
+
+    token.transfer(bob, amount, {"from": alice})
+
+    assert token.balanceOf(alice) == sender_balance - amount
+
+
+def test_receiver_balance_increases(alice, bob, token):
+    receiver_balance = token.balanceOf(bob)
+    amount = token.balanceOf(alice) // 4
+
+    token.transfer(bob, amount, {"from": alice})
+
+    assert token.balanceOf(bob) == receiver_balance + amount
+
+
+def test_total_supply_not_affected(alice, bob, token):
+    total_supply = token.totalSupply()
+    amount = token.balanceOf(alice)
+
+    token.transfer(bob, amount, {"from": alice})
+
+    assert token.totalSupply() == total_supply
+
+
+def test_returns_true(alice, bob, token):
+    amount = token.balanceOf(alice)
+    tx = token.transfer(bob, amount, {"from": alice})
+
+    assert tx.return_value is True
+
+
+def test_transfer_full_balance(alice, bob, token):
+    amount = token.balanceOf(alice)
+    receiver_balance = token.balanceOf(bob)
+
+    token.transfer(bob, amount, {"from": alice})
+
+    assert token.balanceOf(alice) == 0
+    assert token.balanceOf(bob) == receiver_balance + amount
+
+
+def test_transfer_zero_tokens(alice, bob, token):
+    sender_balance = token.balanceOf(alice)
+    receiver_balance = token.balanceOf(bob)
+
+    token.transfer(bob, 0, {"from": alice})
+
+    assert token.balanceOf(alice) == sender_balance
+    assert token.balanceOf(bob) == receiver_balance
+
+
+def test_transfer_to_self(alice, bob, token):
+    sender_balance = token.balanceOf(alice)
+    amount = sender_balance // 4
+
+    token.transfer(alice, amount, {"from": alice})
+
+    assert token.balanceOf(alice) == sender_balance
+
+
+def test_insufficient_balance(alice, bob, token):
+    balance = token.balanceOf(alice)
+
+    with brownie.reverts():
+        token.transfer(bob, balance + 1, {"from": alice})
+
+
+def test_transfer_event_fires(alice, bob, token):
+    amount = token.balanceOf(alice)
+    tx = token.transfer(bob, amount, {"from": alice})
+
+    assert len(tx.events) == 1
+    assert tx.events["Transfer"].values() == [alice, bob, amount]

--- a/tests/token/test_transfer_from.py
+++ b/tests/token/test_transfer_from.py
@@ -1,0 +1,169 @@
+import brownie
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(alice, token):
+    token.mint(alice, 10 ** 21, {"from": alice})
+
+
+def test_sender_balance_decreases(alice, bob, charlie, token):
+    sender_balance = token.balanceOf(alice)
+    amount = sender_balance // 4
+
+    token.approve(bob, amount, {"from": alice})
+    token.transferFrom(alice, charlie, amount, {"from": bob})
+
+    assert token.balanceOf(alice) == sender_balance - amount
+
+
+def test_receiver_balance_increases(alice, bob, charlie, token):
+    receiver_balance = token.balanceOf(charlie)
+    amount = token.balanceOf(alice) // 4
+
+    token.approve(bob, amount, {"from": alice})
+    token.transferFrom(alice, charlie, amount, {"from": bob})
+
+    assert token.balanceOf(charlie) == receiver_balance + amount
+
+
+def test_caller_balance_not_affected(alice, bob, charlie, token):
+    caller_balance = token.balanceOf(bob)
+    amount = token.balanceOf(alice)
+
+    token.approve(bob, amount, {"from": alice})
+    token.transferFrom(alice, charlie, amount, {"from": bob})
+
+    assert token.balanceOf(bob) == caller_balance
+
+
+def test_caller_approval_affected(alice, bob, charlie, token):
+    approval_amount = token.balanceOf(alice)
+    transfer_amount = approval_amount // 4
+
+    token.approve(bob, approval_amount, {"from": alice})
+    token.transferFrom(alice, charlie, transfer_amount, {"from": bob})
+
+    assert token.allowance(alice, bob) == approval_amount - transfer_amount
+
+
+def test_receiver_approval_not_affected(alice, bob, charlie, token):
+    approval_amount = token.balanceOf(alice)
+    transfer_amount = approval_amount // 4
+
+    token.approve(bob, approval_amount, {"from": alice})
+    token.approve(charlie, approval_amount, {"from": alice})
+    token.transferFrom(alice, charlie, transfer_amount, {"from": bob})
+
+    assert token.allowance(alice, charlie) == approval_amount
+
+
+def test_total_supply_not_affected(alice, bob, charlie, token):
+    total_supply = token.totalSupply()
+    amount = token.balanceOf(alice)
+
+    token.approve(bob, amount, {"from": alice})
+    token.transferFrom(alice, charlie, amount, {"from": bob})
+
+    assert token.totalSupply() == total_supply
+
+
+def test_returns_true(alice, bob, charlie, token):
+    amount = token.balanceOf(alice)
+    token.approve(bob, amount, {"from": alice})
+    tx = token.transferFrom(alice, charlie, amount, {"from": bob})
+
+    assert tx.return_value is True
+
+
+def test_transfer_full_balance(alice, bob, charlie, token):
+    amount = token.balanceOf(alice)
+    receiver_balance = token.balanceOf(charlie)
+
+    token.approve(bob, amount, {"from": alice})
+    token.transferFrom(alice, charlie, amount, {"from": bob})
+
+    assert token.balanceOf(alice) == 0
+    assert token.balanceOf(charlie) == receiver_balance + amount
+
+
+def test_transfer_zero_tokens(alice, bob, charlie, token):
+    sender_balance = token.balanceOf(alice)
+    receiver_balance = token.balanceOf(charlie)
+
+    token.approve(bob, sender_balance, {"from": alice})
+    token.transferFrom(alice, charlie, 0, {"from": bob})
+
+    assert token.balanceOf(alice) == sender_balance
+    assert token.balanceOf(charlie) == receiver_balance
+
+
+def test_transfer_zero_tokens_without_approval(alice, bob, charlie, token):
+    sender_balance = token.balanceOf(alice)
+    receiver_balance = token.balanceOf(charlie)
+
+    token.transferFrom(alice, charlie, 0, {"from": bob})
+
+    assert token.balanceOf(alice) == sender_balance
+    assert token.balanceOf(charlie) == receiver_balance
+
+
+def test_insufficient_balance(alice, bob, charlie, token):
+    balance = token.balanceOf(alice)
+
+    token.approve(bob, balance + 1, {"from": alice})
+    with brownie.reverts():
+        token.transferFrom(alice, charlie, balance + 1, {"from": bob})
+
+
+def test_insufficient_approval(alice, bob, charlie, token):
+    balance = token.balanceOf(alice)
+
+    token.approve(bob, balance - 1, {"from": alice})
+    with brownie.reverts():
+        token.transferFrom(alice, charlie, balance, {"from": bob})
+
+
+def test_no_approval(alice, bob, charlie, token):
+    balance = token.balanceOf(alice)
+
+    with brownie.reverts():
+        token.transferFrom(alice, charlie, balance, {"from": bob})
+
+
+def test_revoked_approval(alice, bob, charlie, token):
+    balance = token.balanceOf(alice)
+
+    token.approve(bob, balance, {"from": alice})
+    token.approve(bob, 0, {"from": alice})
+
+    with brownie.reverts():
+        token.transferFrom(alice, charlie, balance, {"from": bob})
+
+
+def test_transfer_to_self(alice, bob, token):
+    sender_balance = token.balanceOf(alice)
+    amount = sender_balance // 4
+
+    token.approve(alice, sender_balance, {"from": alice})
+    token.transferFrom(alice, alice, amount, {"from": alice})
+
+    assert token.balanceOf(alice) == sender_balance
+    assert token.allowance(alice, alice) == sender_balance - amount
+
+
+def test_transfer_to_self_no_approval(alice, bob, token):
+    amount = token.balanceOf(alice)
+
+    with brownie.reverts():
+        token.transferFrom(alice, alice, amount, {"from": alice})
+
+
+def test_transfer_event_fires(alice, bob, charlie, token):
+    amount = token.balanceOf(alice)
+
+    token.approve(bob, amount, {"from": alice})
+    tx = token.transferFrom(alice, charlie, amount, {"from": bob})
+
+    assert len(tx.events) == 1
+    assert tx.events["Transfer"].values() == [alice, charlie, amount]


### PR DESCRIPTION
New token version based off CurveTokenV4

Major changes:

- name/symbol use immutable (eliminate read from storage)
- rm `set_name` function (never used, checked previously deployed LP tokens) 
- add `permit` function [EIP-2612](https://eips.ethereum.org/EIPS/eip-2612#specification)
- Also supports EIP-1271 contract signatures
- Add tests for token (majority copied over from `curve-contract` repo, with addition of testing `permit` function)

Run tests: `brownie test tests/token`

This should enable gauges to have a new function `deposit_with_permit`, allowing users to do 1 tx for deposits into gauges instead of two (approve + deposit)

Inspiration from https://github.com/yearn/yearn-vaults/blob/main/contracts/Vault.vy#L753-L793